### PR TITLE
Add validation for cmail emails

### DIFF
--- a/codechallenges/models.py
+++ b/codechallenges/models.py
@@ -1,8 +1,8 @@
-
 from django.core.validators import validate_email
 from django.db import models
 
 from .validators import validate_carleton_email
+
 
 class CodeChallengeEvent(models.Model):
     title = models.CharField(max_length=150)

--- a/codechallenges/models.py
+++ b/codechallenges/models.py
@@ -1,5 +1,8 @@
+
+from django.core.validators import validate_email
 from django.db import models
 
+from .validators import validate_carleton_email
 
 class CodeChallengeEvent(models.Model):
     title = models.CharField(max_length=150)
@@ -61,6 +64,11 @@ class Submission(models.Model):
         Question, on_delete=models.CASCADE, blank=True, null=True
     )
     attempts = models.IntegerField(default=0)
+
+    def save(self, *args, **kwargs):
+        validate_email(self.email)
+        validate_carleton_email(self.email)
+        super(Submission, self).save(*args, **kwargs)
 
     class Meta:
         unique_together = (

--- a/codechallenges/tests.py
+++ b/codechallenges/tests.py
@@ -166,14 +166,14 @@ class SubmissionTestCase(TestCase):
             answer="Yate",
             correct=False,
             question=self.question1,
-            attempts=5
+            attempts=5,
         )
         submission5 = Submission.objects.create(
             email="robertbabaev@cunet.carleton.ca",
             answer="Yate",
             correct=False,
             question=self.question1,
-            attempts=5
+            attempts=5,
         )
         self.assertNotEquals(submission4, None)
         self.assertNotEquals(submission5, None)

--- a/codechallenges/tests.py
+++ b/codechallenges/tests.py
@@ -104,7 +104,7 @@ class SubmissionTestCase(TestCase):
         self.assertNotEquals(self.question1, None)
 
         submission1 = Submission.objects.create(
-            email="test123@gmail.com",
+            email="test123@cmail.carleton.ca",
             answer="Yote",
             correct=True,
             question=self.question1,
@@ -116,7 +116,7 @@ class SubmissionTestCase(TestCase):
 
         # This should pass because it's not a dupe!
         submission2 = Submission.objects.create(
-            email="test124@gmail.com",
+            email="test124@cmail.carleton.ca",
             answer="Y0te",
             correct=False,
             question=self.question1,
@@ -129,9 +129,51 @@ class SubmissionTestCase(TestCase):
         # This should fail due to duplicate checking
         with self.assertRaises(Exception):
             submission3 = Submission.objects.create(
-                email="test123@gmail.com",
+                email="test123@cmail.carleton.ca",
                 answer="Yate",
                 correct=False,
                 question=self.question1,
                 attempts=5,
             )
+
+    def test_validate_email(self):
+        with self.assertRaises(Exception):
+            submission1 = Submission.objects.create(
+                email="test1@gmail.com",
+                answer="Yate",
+                correct=False,
+                question=self.question1,
+                attempts=5,
+            )
+        with self.assertRaises(Exception):
+            submission2 = Submission.objects.create(
+                email="carleton.ca",
+                answer="Yate",
+                correct=False,
+                question=self.question1,
+                attempts=5,
+            )
+        with self.assertRaises(Exception):
+            submission3 = Submission.objects.create(
+                email="robert@carleton.ca",
+                answer="Yate",
+                correct=False,
+                question=self.question1,
+                attempts=5,
+            )
+        submission4 = Submission.objects.create(
+            email="robertbabaev@cmail.carleton.ca",
+            answer="Yate",
+            correct=False,
+            question=self.question1,
+            attempts=5
+        )
+        submission5 = Submission.objects.create(
+            email="robertbabaev@cunet.carleton.ca",
+            answer="Yate",
+            correct=False,
+            question=self.question1,
+            attempts=5
+        )
+        self.assertNotEquals(submission4, None)
+        self.assertNotEquals(submission5, None)

--- a/codechallenges/validators.py
+++ b/codechallenges/validators.py
@@ -1,0 +1,9 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+import re
+
+def validate_carleton_email(value):
+    search = re.findall("(cmail|cunet)\.carleton\.ca", value)
+    if len(search) != 1:
+        raise ValidationError(_("Invalid email domain, must be carleton.ca email."), status='invalid')

--- a/codechallenges/validators.py
+++ b/codechallenges/validators.py
@@ -5,7 +5,8 @@ import re
 
 
 def validate_carleton_email(value):
-    search = re.findall("(cmail|cunet)\.carleton\.ca", value)
+    search = re.findall(r"(cmail|cunet)\.carleton\.ca", value)
+    print(search)
     if len(search) != 1:
         raise ValidationError(
             _("Invalid email domain, must be carleton.ca email."), status="invalid"

--- a/codechallenges/validators.py
+++ b/codechallenges/validators.py
@@ -3,7 +3,10 @@ from django.utils.translation import gettext_lazy as _
 
 import re
 
+
 def validate_carleton_email(value):
     search = re.findall("(cmail|cunet)\.carleton\.ca", value)
     if len(search) != 1:
-        raise ValidationError(_("Invalid email domain, must be carleton.ca email."), status='invalid')
+        raise ValidationError(
+            _("Invalid email domain, must be carleton.ca email."), status="invalid"
+        )


### PR DESCRIPTION
Resolve #36. Using regex to validate cmail/cunet subdomain emails. Will add more emails as necessary.